### PR TITLE
[16.0] account_reconcile_oca : 2 changes

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -40,6 +40,7 @@ class AccountBankStatementLine(models.Model):
     )
     manual_partner_id = fields.Many2one(
         "res.partner",
+        domain=[('parent_id', '=', False)],
         check_company=True,
         store=False,
         default=False,

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -155,6 +155,7 @@
                         />
                     </div>
                 </div>
+                <field name="id" invisible="1" />
                 <field name="name" invisible="1" />
                 <field name="can_reconcile" invisible="1" />
                 <field name="partner_id" invisible="1" />
@@ -188,7 +189,7 @@
                         <field
                             name="add_account_move_line_id"
                             widget="account_reconcile_oca_match"
-                            domain="[('parent_state', '=', 'posted'),('amount_residual', '!=', 0),('account_id.reconcile', '=', True), ('company_id', '=', company_id)]"
+                            domain="[('parent_state', '=', 'posted'),('amount_residual', '!=', 0),('account_id.reconcile', '=', True), ('company_id', '=', company_id), ('statement_line_id', '!=', id)]"
                             context="{'search_default_partner_id': partner_id, 'tree_view_ref': 'account_reconcile_oca.account_move_line_tree_reconcile_view', 'search_view_ref': 'account_reconcile_oca.account_move_line_search_reconcile_view'}"
                         />
                     </page>

--- a/account_reconcile_oca/views/account_move_line.xml
+++ b/account_reconcile_oca/views/account_move_line.xml
@@ -41,7 +41,7 @@
                     <field name="account_id" />
                     <field name="account_root_id" />
                     <field name="account_type" />
-                    <field name="partner_id" />
+                    <field name="partner_id" domain="[('parent_id', '=', False)]"/>
                     <field name="journal_id" />
                     <field
                     name="move_id"


### PR DESCRIPTION
- only select/search parent partner (we are in accounting, so we only deal with parent partners, not children partners)
- filter out the account move corresponding to the bank statement line we are currently processing from the reconciliation proposals