### PR TITLE
[16.0] account_reconcile_oca: Add analytic distribution in the "manual operations" tab

### DIFF
--- a/account_reconcile_oca/models/account_bank_statement_line.py
+++ b/account_reconcile_oca/models/account_bank_statement_line.py
@@ -10,7 +10,11 @@ from odoo.tools import float_is_zero
 
 class AccountBankStatementLine(models.Model):
     _name = "account.bank.statement.line"
-    _inherit = ["account.bank.statement.line", "account.reconcile.abstract"]
+    _inherit = [
+        "account.bank.statement.line",
+        "account.reconcile.abstract",
+        "analytic.mixin",
+    ]
 
     reconcile_data_info = fields.Serialized(inverse="_inverse_reconcile_data_info")
     reconcile_mode = fields.Selection(
@@ -196,6 +200,7 @@ class AccountBankStatementLine(models.Model):
                 precision_digits=self.currency_id.decimal_places,
             )
             or self.manual_account_id.id != line["account_id"][0]
+            or self.analytic_distribution != line.get("analytic_distribution")
             or self.manual_name != line["name"]
             or (
                 self.manual_partner_id and self.manual_partner_id.name_get()[0] or False
@@ -216,6 +221,7 @@ class AccountBankStatementLine(models.Model):
                             "manual_delete": False,
                             "manual_reference": False,
                             "manual_account_id": False,
+                            "analytic_distribution": False,
                             "manual_amount": False,
                             "manual_name": False,
                             "manual_partner_id": False,
@@ -229,6 +235,7 @@ class AccountBankStatementLine(models.Model):
                     continue
                 else:
                     self.manual_account_id = line["account_id"][0]
+                    self.analytic_distribution = line.get("analytic_distribution")
                     self.manual_amount = line["amount"]
                     self.manual_name = line["name"]
                     self.manual_partner_id = (
@@ -250,6 +257,7 @@ class AccountBankStatementLine(models.Model):
 
     @api.onchange(
         "manual_account_id",
+        "analytic_distribution",
         "manual_partner_id",
         "manual_name",
         "manual_amount",
@@ -270,6 +278,7 @@ class AccountBankStatementLine(models.Model):
                             "account_id": self.manual_account_id.name_get()[0]
                             if self.manual_account_id
                             else [False, _("Undefined")],
+                            "analytic_distribution": self.analytic_distribution,
                             "amount": self.manual_amount,
                             "credit": -self.manual_amount
                             if self.manual_amount < 0
@@ -533,7 +542,7 @@ class AccountBankStatementLine(models.Model):
                         | line
                     )
             move.invalidate_recordset()
-        move._post()
+        move.with_context(validate_analytic=True)._post(soft=False)
         for _account, lines in to_reconcile.items():
             lines.reconcile()
 
@@ -554,7 +563,7 @@ class AccountBankStatementLine(models.Model):
                 ]
             }
         )
-        self.move_id.action_post()
+        self.move_id.with_context(validate_analytic=True)._post(soft=False)
 
     def _unreconcile_bank_line_keep(self, data):
         raise UserError(_("Keep suspense move lines mode cannot be unreconciled"))

--- a/account_reconcile_oca/views/account_bank_statement_line.xml
+++ b/account_reconcile_oca/views/account_bank_statement_line.xml
@@ -121,7 +121,7 @@
                     <button
                             name="reconcile_bank_line"
                             type="object"
-                            string="Reconcile"
+                            string="Confirm"
                             class="btn btn-primary"
                             attrs="{'invisible': ['|', ('is_reconciled', '=', True), ('can_reconcile', '=', False)]}"
                         />
@@ -135,7 +135,7 @@
                         <button
                             name="unreconcile_bank_line"
                             type="object"
-                            string="Unreconcile"
+                            string="Reset"
                             class="btn btn-warning"
                             attrs="{'invisible': [('is_reconciled', '=', False)]}"
                             confirm="Are you sure that the move should be unreconciled?"
@@ -201,6 +201,13 @@
                                 <field
                                     name="manual_account_id"
                                     string="Account"
+                                    attrs="{'readonly': ['|', '|', ('manual_reference', '=', False), ('is_reconciled', '=', True), ('manual_line_id', '!=', False)]}"
+                                />
+                                <field
+                                    name="analytic_distribution"
+                                    widget="analytic_distribution"
+                                    groups="analytic.group_analytic_accounting"
+                                    options="{'account_field': 'manual_account_id'}"
                                     attrs="{'readonly': ['|', '|', ('manual_reference', '=', False), ('is_reconciled', '=', True), ('manual_line_id', '!=', False)]}"
                                 />
                                 <field


### PR DESCRIPTION
1) I have a low knowledge of the code of this module, so I probably missing things that need to be changed (or changed things that I should have changed, etc...) so please check carefully this PR. You'll certainly need to update/modify it.
2) For the moment, even if you configure an analytic plan as "mandatory", it will be accepted without error even when not checked. To make it work, AFAIK, you have to set "display_type" to "product" when the line comes from the "manual operations" (but don't set it to "product" when for the bank line nor when it comes from the "Reconcile" tab). cf https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_move_line.py#L2464
3) The analytic distribution is not displayed where you see the journal entry... it would be cool to see this info there, to make sure everything is ok before confirming the move.